### PR TITLE
Revise the reset functionality to provide a 100% reset of the system

### DIFF
--- a/source/Utils/DebuggingMacros.h
+++ b/source/Utils/DebuggingMacros.h
@@ -31,8 +31,11 @@
 extern Serial0 gDebugSerial;
 
 void initDebugSerial();
+void stopDebugSerial();
+
 
 #define DEBUG_INIT_SERIAL_OUTPUT()      initDebugSerial();
+#define DEBUG_STOP_SERIAL_OUTPUT()      stopDebugSerial();
 
 #define DEBUG_TABLE_HEADER( S )         gDebugSerial.println(S);
 
@@ -68,6 +71,7 @@ void initDebugSerial();
 
 
 #define DEBUG_INIT_SERIAL_OUTPUT()
+#define DEBUG_STOP_SERIAL_OUTPUT()
 #define DEBUG_TABLE_HEADER( S )
 #define DEBUG_TABLE_START( S )
 #define DEBUG_TABLE_ITEM( X )

--- a/source/Utils/DebuggingSupport.cpp
+++ b/source/Utils/DebuggingSupport.cpp
@@ -39,6 +39,8 @@ Serial0 gDebugSerial;
 
 #include <avr/pgmspace.h>
 
+
+
 // Function to initialize the debug serial connection
 void initDebugSerial()
 {
@@ -50,6 +52,21 @@ void initDebugSerial()
     char tmp[32];
     strcpy_P( tmp, PSTR( "CARRT Debugging Output...\n" ) );
     gDebugSerial.println( tmp );
+}
+
+
+
+// Function to close the debug serial connection
+void stopDebugSerial()
+{
+    char tmp[36];
+    strcpy_P( tmp, PSTR( "CARRT Debugging Output Stopped\n" ) );
+    gDebugSerial.println( tmp );
+
+    // Give serial a chance to stabilize
+    delayMilliseconds( 500 );
+
+    gDebugSerial.stop();
 }
 
 


### PR DESCRIPTION
Modified main() to be fully reset-able.  Enabled by some recent changes in AVRTools.